### PR TITLE
[008-FIX-BUG-SIGN-IN] 탈퇴 회원에게 로그인이 허용되는 문제 해결

### DIFF
--- a/src/main/java/com/myecommerce/MyECommerce/repository/member/MemberRepository.java
+++ b/src/main/java/com/myecommerce/MyECommerce/repository/member/MemberRepository.java
@@ -12,5 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByTelephone(String telephone);
 
     // 사용자ID에 대한 회원정보 조회
-    Optional<Member> findByUserId(String userId);
+    Optional<Member> findByUserIdAndDelYn(String userId, Character delYn);
 }

--- a/src/main/java/com/myecommerce/MyECommerce/service/member/MemberService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/member/MemberService.java
@@ -70,7 +70,7 @@ public class MemberService {
     /** 로그인 **/
     public String signIn(RequestMemberDto memberDto) {
         // 1. 사용자ID 검증 (사용자 조회)
-        Member member = memberRepository.findByUserId(memberDto.getUserId())
+        Member member = memberRepository.findByUserIdAndDelYn(memberDto.getUserId(), 'N')
                 .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
 
         // 2. 비밀번호 검증

--- a/src/main/java/com/myecommerce/MyECommerce/service/member/SignInAuthenticationService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/member/SignInAuthenticationService.java
@@ -24,7 +24,7 @@ public class SignInAuthenticationService implements UserDetailsService {
      */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findByUserId(username)
+        return memberRepository.findByUserIdAndDelYn(username, 'N')
                 .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
     }
 

--- a/src/test/java/com/myecommerce/MyECommerce/service/member/MemberServiceTest.java
+++ b/src/test/java/com/myecommerce/MyECommerce/service/member/MemberServiceTest.java
@@ -184,8 +184,8 @@ class MemberServiceTest {
         Date expirationDate = new Date(nowTimeMs + (1000L * 60 * 10)); // 현재시간+10분
         long validTimeMs = expirationDate.getTime() - nowTimeMs;
 
-        // stub(가설) : memberRepository.findByUserId() 실행 시 빈값 반환 예상.
-        given(memberRepository.findByUserId(any()))
+        // stub(가설) : memberRepository.findByUserIdAndDelYn() 실행 시 빈값 반환 예상.
+        given(memberRepository.findByUserIdAndDelYn(any(), any()))
                 .willReturn(Optional.ofNullable(Member.builder()
                         .id(id)
                         .userId(userId)


### PR DESCRIPTION
Bug
---
1. 로그인 시 탈퇴한 회원에 대해 로그인 불가처리
    > 회원탈퇴 시 del_yn='Y'로 회원을 논리적 삭제하므로 로그인가능 유저 조회 시 del_yn='N'인 회원에 대해서만 조회하도록 수정.
    

Test
---
- [X] API 호출 테스트
- [X] Controller 테스트코드 작성 및 테스트
- [X] Service 성공 테스트 케이스 작성 및 테스트
- [ ] Service 실패 테스트 케이스 작성 및 테스트

