### PR TITLE
[009-SHOP-MODIFY] 판매자권한 상품수정 api 생성

### DIFF
--- a/src/main/java/com/myecommerce/MyECommerce/controller/ProductionController.java
+++ b/src/main/java/com/myecommerce/MyECommerce/controller/ProductionController.java
@@ -1,5 +1,6 @@
 package com.myecommerce.MyECommerce.controller;
 
+import com.myecommerce.MyECommerce.dto.production.RequestModifyProductionDto;
 import com.myecommerce.MyECommerce.dto.production.RequestProductionDto;
 import com.myecommerce.MyECommerce.dto.production.ResponseProductionDto;
 import com.myecommerce.MyECommerce.entity.member.Member;
@@ -34,6 +35,15 @@ public class ProductionController {
     /**
      * 상품, 상품옵션 수정 put /production/{id}
      **/
+    @PutMapping
+    @PreAuthorize("hasAuthority('SELLER')")
+    public ResponseEntity<ResponseProductionDto> modifyProduction(
+            @RequestBody @Valid RequestModifyProductionDto production,
+            @AuthenticationPrincipal Member member) {
+
+        return ResponseEntity.ok(
+                productionService.modifyProduction(production, member));
+    }
 
     /**
      * 상품, 상품옵션 삭제 delete /production/{id}

--- a/src/main/java/com/myecommerce/MyECommerce/dto/production/RequestModifyProductionDto.java
+++ b/src/main/java/com/myecommerce/MyECommerce/dto/production/RequestModifyProductionDto.java
@@ -1,0 +1,30 @@
+package com.myecommerce.MyECommerce.dto.production;
+
+import com.myecommerce.MyECommerce.type.ProductionSaleStatusType;
+import com.myecommerce.MyECommerce.validation.EnumValid;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestModifyProductionDto {
+
+    @NotNull
+    @Min(1)
+    private Long id;
+
+    private String description;
+
+    @EnumValid(enumClass = ProductionSaleStatusType.class)
+    private ProductionSaleStatusType saleStatus;
+
+    @Valid
+    private List<RequestModifyProductionOptionDto> options;
+
+}

--- a/src/main/java/com/myecommerce/MyECommerce/dto/production/RequestModifyProductionOptionDto.java
+++ b/src/main/java/com/myecommerce/MyECommerce/dto/production/RequestModifyProductionOptionDto.java
@@ -1,0 +1,32 @@
+package com.myecommerce.MyECommerce.dto.production;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestModifyProductionOptionDto {
+
+    private Long id;
+
+    @Size(min=1, max=100, message = "옵션코드는 최소 1자, 최대 100자로 제한됩니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9\\-]*$", message = "옵션코드는 영문자, 숫자만 사용 가능합니다.\n특수문자는 -만 허용하며 첫 글자로 사용 불가합니다.")
+    private String optionCode;
+
+    @Size(min=1, max=200, message = "옵션명은 최소 1자, 최대 200자로 제한됩니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ0-9][a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ0-9\\s]*$", message = "옵션명에 특수문자 사용이 불가합니다.")
+    private String optionName;
+
+    @NotNull(message = "해당 옵션의 가격을 입력해주세요.")
+    @DecimalMin(value = "1", message = "해당 옵션의 가격 입력해주세요.")
+    private BigDecimal price;
+
+    @Min(value = 1, message = "해당 옵션의 판매가능 수량을 입력해주세요.")
+    private int quantity;
+
+}

--- a/src/main/java/com/myecommerce/MyECommerce/exception/errorcode/ProductionErrorCode.java
+++ b/src/main/java/com/myecommerce/MyECommerce/exception/errorcode/ProductionErrorCode.java
@@ -9,12 +9,16 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ProductionErrorCode implements CommonErrorCode {
 
-    // 상품 객체 validation check
+    // 상품 validation check
     ALREADY_REGISTERED_CODE(HttpStatus.BAD_REQUEST.value(), "이미 등록된 상품코드입니다."),
 
-    // 상품옵션 객체 validation check
-    ALREADY_REGISTERED_OPTION_CODE(HttpStatus.BAD_REQUEST.value(), "이미 등록된 상품옵션코드입니다.")
+    // 상품옵션 validation check
+    ALREADY_REGISTERED_OPTION_CODE(HttpStatus.BAD_REQUEST.value(), "이미 등록된 상품옵션코드입니다."),
+    ENTER_DUPLICATED_OPTION_CODE(HttpStatus.BAD_REQUEST.value(), "중복된 상품옵션코드 입력은 불가합니다."),
 
+    // 상품수정 validation check
+    NO_EDIT_PERMISSION(HttpStatus.BAD_REQUEST.value(), "본인이 등록한 상품만 수정 가능합니다."),
+    NO_EDIT_DELETION_STATUS(HttpStatus.BAD_REQUEST.value(), "판매종료된 상품에 대해 수정 불가합니다.")
     ;
 
 

--- a/src/main/java/com/myecommerce/MyECommerce/exception/errorcode/ProductionErrorCode.java
+++ b/src/main/java/com/myecommerce/MyECommerce/exception/errorcode/ProductionErrorCode.java
@@ -18,7 +18,8 @@ public enum ProductionErrorCode implements CommonErrorCode {
 
     // 상품수정 validation check
     NO_EDIT_PERMISSION(HttpStatus.BAD_REQUEST.value(), "본인이 등록한 상품만 수정 가능합니다."),
-    NO_EDIT_DELETION_STATUS(HttpStatus.BAD_REQUEST.value(), "판매종료된 상품에 대해 수정 불가합니다.")
+    NO_EDIT_DELETION_STATUS(HttpStatus.BAD_REQUEST.value(), "판매종료된 상품에 대해 수정 불가합니다."),
+    NO_EDIT_FOR_NOT_EXIST_OPTION(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 상품옵션에 대한 수정은 불가합니다."),
     ;
 
 

--- a/src/main/java/com/myecommerce/MyECommerce/mapper/ModifyProductionOptionMapper.java
+++ b/src/main/java/com/myecommerce/MyECommerce/mapper/ModifyProductionOptionMapper.java
@@ -1,0 +1,18 @@
+package com.myecommerce.MyECommerce.mapper;
+
+import com.myecommerce.MyECommerce.dto.production.RequestModifyProductionOptionDto;
+import com.myecommerce.MyECommerce.dto.production.ResponseProductionOptionDto;
+import com.myecommerce.MyECommerce.entity.production.ProductionOption;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface ModifyProductionOptionMapper {
+
+    ModifyProductionOptionMapper INSTANCE = Mappers.getMapper(ModifyProductionOptionMapper.class);
+
+    ResponseProductionOptionDto toDto(ProductionOption productionOption);
+
+    ProductionOption toEntity(RequestModifyProductionOptionDto productionOptionDto);
+
+}

--- a/src/main/java/com/myecommerce/MyECommerce/repository/production/ProductionOptionRepository.java
+++ b/src/main/java/com/myecommerce/MyECommerce/repository/production/ProductionOptionRepository.java
@@ -17,4 +17,7 @@ public interface ProductionOptionRepository extends JpaRepository<ProductionOpti
             " WHERE PRD.code = ?1" +
             " AND OPTION.optionCode IN (?2)")
     List<Production> findByProductionCodeAndOptionCodeIn(String productionCode, List<String> optionCodes);
+
+    // 상품ID에 해당하는 상품옵션목록 조회
+    List<ProductionOption> findByProductionId(Long productionId);
 }

--- a/src/main/java/com/myecommerce/MyECommerce/repository/production/ProductionRepository.java
+++ b/src/main/java/com/myecommerce/MyECommerce/repository/production/ProductionRepository.java
@@ -10,4 +10,7 @@ import java.util.Optional;
 public interface ProductionRepository extends JpaRepository<Production, Long> {
     // 판매자의 동일 상품코드 조회
     Optional<Production> findBySellerAndCode(long id, String code);
+
+    // 판매자, 상품ID에 일치하는 상품 조회
+    Optional<Production> findByIdAndSeller(Long id, Long sellerId);
 }

--- a/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
@@ -106,19 +106,14 @@ public class ProductionService {
         // 상품 설명, 판매상태 변경
         production.setDescription(requestProductionDto.getDescription());
         production.setSaleStatus(requestProductionDto.getSaleStatus());
-        Production updatedProduction = productionRepository.save(production);
-
-        // 옵션목록 조회
-        List<ProductionOption> optionList =
-                productionOptionRepository.findByProductionId(production.getId());
 
         // 상품옵션 수량 변경
         // 기존 데이터와 id가 일치하는 입력데이터 찾아 값 입력
         for (int i = 0; i < requestUpdateOptionList.size(); i++) {
-            for(int j = 0; j < optionList.size(); j++) {
+            for(int j = 0; j < production.getOptions().size(); j++) {
 
-                if(optionList.get(j).getId().equals(requestUpdateOptionList.get(i).getId())) {
-                    optionList.get(j).setQuantity(requestUpdateOptionList.get(i).getQuantity());
+                if(production.getOptions().get(j).getId().equals(requestUpdateOptionList.get(i).getId())) {
+                    production.getOptions().get(j).setQuantity(requestUpdateOptionList.get(i).getQuantity());
                     break;
                 }
             }
@@ -129,14 +124,11 @@ public class ProductionService {
             // 상품옵션목록의 JPA 연관관계를 위해 옵션에 상품객체 셋팅
             option.setProduction(production);
             // 조회한 상품옵션목록에 신규옵션 추가
-            optionList.add(option);
+            production.getOptions().add(option);
         });
 
-        // 상품옵션 변경, 저장
-        saveProductionOption(optionList, production);
-
         // 상품, 상품옵션목록 반환
-        return productionMapper.toDto(updatedProduction);
+        return productionMapper.toDto(production);
     }
 
 

--- a/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
@@ -119,15 +119,21 @@ public class ProductionService {
 
                 if(optionList.get(j).getId().equals(requestUpdateOptionList.get(i).getId())) {
                     optionList.get(j).setQuantity(requestUpdateOptionList.get(i).getQuantity());
-                    // 상품옵션목록 등록(수정)
-                    productionOptionRepository.save(optionList.get(j));
                     break;
                 }
             }
         }
 
-        // 상품옵션 추가 등록
-        saveProductionOption(requestInsertOptionList, production);
+        // 신규 상품옵션 추가
+        requestInsertOptionList.forEach(option -> {
+            // 상품옵션목록의 JPA 연관관계를 위해 옵션에 상품객체 셋팅
+            option.setProduction(production);
+            // 조회한 상품옵션목록에 신규옵션 추가
+            optionList.add(option);
+        });
+
+        // 상품옵션 변경, 저장
+        saveProductionOption(optionList, production);
 
         // 상품, 상품옵션목록 반환
         return productionMapper.toDto(updatedProduction);
@@ -176,7 +182,7 @@ public class ProductionService {
 
         // 2. 입력받은 옵션코드목록과 등록된 옵션코드목록 중복 체크
         if (!productionOptionRepository.findByProductionCodeAndOptionCodeIn(
-                productionCode, optionCodeSet.stream().toList())
+                        productionCode, optionCodeSet.stream().toList())
                 .isEmpty()) {
             throw new ProductionException(ALREADY_REGISTERED_OPTION_CODE);
         }

--- a/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
@@ -68,8 +68,12 @@ public class ProductionService {
     @Transactional
     public ResponseProductionDto modifyProduction(RequestModifyProductionDto requestProductionDto,
                                                   Member member) {
+        // 상품 조회 및 상품 판매자 체크
+        Production production = getProductionEntityByIdAndSeller(
+                requestProductionDto.getId(), member.getId());
+
         // validation check
-        updateProductionValidationCheck(requestProductionDto, member);
+        updateProductionValidationCheck(production, requestProductionDto);
 
         // 수정할 옵션목록 dto -> entity 변환
         List<ProductionOption> requestUpdateOptionList =
@@ -77,10 +81,6 @@ public class ProductionService {
         // 신규 저장 옵션목록 dto -> entity 변환
         List<ProductionOption> requestInsertOptionList =
                 convertToInsertOptionEntities(requestProductionDto);
-
-        // 상품 조회
-        Production production = getProductionEntityByIdAndSeller(
-                requestProductionDto.getId(), member.getId());
 
         // 상품 설명, 판매상태 변경
         updateProduction(production, requestProductionDto);
@@ -162,12 +162,8 @@ public class ProductionService {
     }
 
     // 상품수정 validation check
-    private void updateProductionValidationCheck(RequestModifyProductionDto requestProductionDto,
-                                                 Member member) {
-        // 상품 판매자 체크
-        Production production = getProductionEntityByIdAndSeller(
-                requestProductionDto.getId(), member.getId());
-
+    private void updateProductionValidationCheck(Production production,
+                                                 RequestModifyProductionDto requestProductionDto) {
         // 상품 기존 판매상태 체크
         if (production.getSaleStatus() == DELETION) {
             throw new ProductionException(NO_EDIT_DELETION_STATUS);

--- a/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
@@ -90,7 +90,7 @@ public class ProductionService {
         insertOptions(requestInsertOptionList, production);
 
         // 상품, 상품옵션목록 반환
-        return productionMapper.toDto(production);
+        return productionMapper.toDto(productionRepository.save(production));
     }
 
     // 상품 insert

--- a/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
@@ -93,13 +93,6 @@ public class ProductionService {
             throw new ProductionException(NO_EDIT_DELETION_STATUS);
         }
 
-        // 상품 수정한 판매상태 체크 (상품 판매상태를 DELETION으로 변경할 때 수정불가)
-        if (requestProductionDto.getSaleStatus() == DELETION) {
-            // 상품 판매상태 수정해 반환
-            production.setSaleStatus(requestProductionDto.getSaleStatus());
-            return productionMapper.toDto(productionRepository.save(production));
-        }
-
         // 상품옵션목록 중복체크
         checkIfOptionCodeExists(requestInsertOptionList, production.getCode());
 

--- a/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
@@ -60,21 +60,7 @@ public class ProductionService {
         return productionMapper.toDto(savedProduction);
     }
 
-    private void saveProductionOption(List<RequestProductionOptionDto> options, Production savedProduction) {
-        // 상품옵션목록 dto -> entity 변환
-        List<ProductionOption> optionEntityList = options.stream()
-                .map(productionOptionMapper::toEntity)
-                .toList();
-
-        optionEntityList.forEach(optionEntity -> {
-            // 상품옵션목록의 JPA 연관관계를 위해 옵션에 상품객체 셋팅
-            optionEntity.setProduction(savedProduction);
-            // 상품옵션목록 중복체크
-            checkIfOptionCodeExists(optionEntity);
-            // 상품옵션목록 등록
-            productionOptionRepository.save(optionEntity);
-        });
-
+    // 상품 insert
     private Production saveProduction(Production production, Member member) {
         production.setSeller(member.getId());
         production.setSaleStatus(ON_SALE);
@@ -84,6 +70,7 @@ public class ProductionService {
         return productionRepository.save(production);
     }
 
+    // 상품옵션 insert
     private void saveProductionOption(List<ProductionOption> optionList, Production savedProduction) {
         optionList.forEach(option -> {
             // 상품옵션목록의 JPA 연관관계를 위해 옵션에 상품객체 셋팅
@@ -93,6 +80,7 @@ public class ProductionService {
         });
     }
 
+    // 상품 중복체크
     private void checkIfProductionCodeExists(Long sellerId, String code) {
         productionRepository.findBySellerAndCode(sellerId, code)
                 .ifPresent(existingProduction -> {
@@ -100,6 +88,7 @@ public class ProductionService {
                 });
     }
 
+    // 상품옵션 중복체크
     private void checkIfOptionCodeExists(List<ProductionOption> options, String productionCode) {
         // 중복코드 제거된 옵션코드목록 set
         Set<String> optionCodeSet = options.stream()

--- a/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
+++ b/src/main/java/com/myecommerce/MyECommerce/service/production/ProductionService.java
@@ -90,7 +90,7 @@ public class ProductionService {
         insertOptions(requestInsertOptionList, production);
 
         // 상품, 상품옵션목록 반환
-        return productionMapper.toDto(productionRepository.save(production));
+        return productionMapper.toDto(production);
     }
 
     // 상품 insert

--- a/src/main/java/com/myecommerce/MyECommerce/type/ProductionSaleStatusType.java
+++ b/src/main/java/com/myecommerce/MyECommerce/type/ProductionSaleStatusType.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum ProductionSaleStatusType {
     ON_SALE("판매중"),
+    DISCONTINUED("판매중단"),
     DELETION("삭제")
     ;
 

--- a/src/test/java/com/myecommerce/MyECommerce/service/production/ProductionServiceTest.java
+++ b/src/test/java/com/myecommerce/MyECommerce/service/production/ProductionServiceTest.java
@@ -289,37 +289,6 @@ class ProductionServiceTest {
                 .build();
 
         // 업데이트한 상품옵션 결과 DTO
-        ProductionOption expectedResponseUpdateOptionEntity =
-                ProductionOption.builder()
-                        .id(originOptionEntity.getId())
-                        .optionCode(originOptionEntity.getOptionCode())
-                        .optionName(originOptionEntity.getOptionName())
-                        .price(originOptionEntity.getPrice())
-                        .quantity(updateQuantity)
-                        .build();
-        ProductionOption expectedResponseInsertOptionEntity =
-                ProductionOption.builder()
-                        .id(3L)
-                        .optionCode(optionCode)
-                        .optionName(optionName)
-                        .price(price)
-                        .quantity(quantity)
-                        .build();
-        List<ProductionOption> expectedResponseOptionEntityList = new ArrayList<>();
-        expectedResponseOptionEntityList.add(expectedResponseUpdateOptionEntity);
-        expectedResponseOptionEntityList.add(expectedResponseInsertOptionEntity);
-
-        Production expectedProductionEntity = Production.builder()
-                .id(originProductionEntity.getId())
-                .seller(originProductionEntity.getSeller())
-                .code(originProductionEntity.getCode())
-                .name(originProductionEntity.getName())
-                .category(originProductionEntity.getCategory())
-                .description(updateDescription)
-                .saleStatus(updateSaleStatus)
-                .options(expectedResponseOptionEntityList)
-                .build();
-
         ResponseProductionOptionDto expectedResponseUpdateOptionDto =
                 ResponseProductionOptionDto.builder()
                         .id(originOptionEntity.getId())
@@ -371,19 +340,14 @@ class ProductionServiceTest {
                 productionCode, Collections.singletonList(insertReqOptEntity.getOptionCode())))
                 .willReturn(new ArrayList());
 
-        given(productionMapper.toDto(expectedProductionEntity))
+        given(productionMapper.toDto(any(Production.class)))
                 .willReturn(expectedResultProductionDto);
-
-        // stubbing: productionRepository.save() 호출 시 반환할 값 설정
-        given(productionRepository.save(any(Production.class)))
-                .willReturn(expectedProductionEntity); // 변경된 생산 정보 반환
 
         // when
         ResponseProductionDto responseProductionDto =
                 productionService.modifyProduction(requestProductionDto, member);
 
         // then
-        verify(productionRepository, times(1)).save(originProductionEntity); // update 1번
         // 1. 상품 수정 검증
         assertEquals(requestProductionDto.getId(), responseProductionDto.getId());
         assertEquals(requestProductionDto.getDescription(), responseProductionDto.getDescription());

--- a/src/test/java/com/myecommerce/MyECommerce/service/production/ProductionServiceTest.java
+++ b/src/test/java/com/myecommerce/MyECommerce/service/production/ProductionServiceTest.java
@@ -14,6 +14,7 @@ import com.myecommerce.MyECommerce.type.ProductionSaleStatusType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -340,7 +341,11 @@ class ProductionServiceTest {
                 productionCode, Collections.singletonList(insertReqOptEntity.getOptionCode())))
                 .willReturn(new ArrayList());
 
-        given(productionMapper.toDto(any(Production.class)))
+        // ArgumentCaptor 생성
+        ArgumentCaptor<Production> productionCaptor = ArgumentCaptor.forClass(Production.class);
+
+        // stub(가설) : productionMapper.toDto() 실행 시 productionCaptor로 인자를 캡처하도록 설정.
+        given(productionMapper.toDto(productionCaptor.capture()))
                 .willReturn(expectedResultProductionDto);
 
         // when
@@ -348,6 +353,12 @@ class ProductionServiceTest {
                 productionService.modifyProduction(requestProductionDto, member);
 
         // then
+        // 0. toDto에 전달된 인자 캡처 후 검증
+        Production capturedProduction = productionCaptor.getValue();
+        assertEquals(requestProductionDto.getId(), capturedProduction.getId());
+        assertEquals(requestProductionDto.getDescription(), capturedProduction.getDescription());
+        assertEquals(requestProductionDto.getSaleStatus(), capturedProduction.getSaleStatus());
+
         // 1. 상품 수정 검증
         assertEquals(requestProductionDto.getId(), responseProductionDto.getId());
         assertEquals(requestProductionDto.getDescription(), responseProductionDto.getDescription());
@@ -361,18 +372,11 @@ class ProductionServiceTest {
         ResponseProductionOptionDto responseUpdatedOption = responseProductionDto.getOptions().get(0);
         assertEquals(requestUpdateOption.getId(), responseUpdatedOption.getId());
         assertEquals(requestUpdateOption.getQuantity(), responseUpdatedOption.getQuantity());
-        assertEquals(originOptionEntity.getOptionCode(), responseUpdatedOption.getOptionCode());
-        assertEquals(originOptionEntity.getOptionName(), responseUpdatedOption.getOptionName());
-        assertEquals(originOptionEntity.getPrice(), responseUpdatedOption.getPrice());
         // 3. 상품옵션 신규등록 검증
         RequestModifyProductionOptionDto requestInsertOption = requestProductionDto.getOptions().get(1);
         ResponseProductionOptionDto responseInsertedOption = responseProductionDto.getOptions().get(1);
         assertNull(requestInsertOption.getId());
         assertEquals(3L, responseInsertedOption.getId());
-        assertEquals(requestInsertOption.getOptionCode(), responseInsertedOption.getOptionCode());
-        assertEquals(requestInsertOption.getOptionName(), responseInsertedOption.getOptionName());
-        assertEquals(requestInsertOption.getPrice(), responseInsertedOption.getPrice());
-        assertEquals(requestInsertOption.getQuantity(), responseInsertedOption.getQuantity());
     }
 
 }

--- a/study/default-study.md
+++ b/study/default-study.md
@@ -712,6 +712,25 @@ OOP 관점에서 봤을 때 인터페이스는 다형성 혹은 개방 폐쇄 �
 
  
 ### < 테스트코드 검증 >
+- 전달인자, 반환값에 대한 검증
+  - 검증할 때 변경되지 않는 값들에 대해서는 반드시 검증할 필요없음.
+  - 특히, 테스트의 목표가 변경된 값들이 올바르게 처리되었는지를 확인하는 것이라면, 변경되지 않은 값들은 검증 대상에서 제외가능.
+
+- 변경된 값들 필수 검증
+  - 효율성
+    - 모든 값을 검증하면 너무 많은 검증이 이루어지게 되며, 테스트 코드가 불필요하게 복잡해짐. 
+    - 특히 변경되지 않은 값들은 이미 예상할 수 있기 때문에 검증을 생략해도 문제없음.
+  - 테스트 목적
+    - 테스트는 로직이 예상대로 작동하는지 확인해 수정된 값들이 제대로 처리되는지 것이므로 변경된 값에 대해서만 집중.
+
+- 변경되지 않은 값들에 대한 간접적 검증.
+  > 변경되지 않아야 할 부분도 간접적으로 검증하는 것이 중요.
+  > 만약 변경되지 않은 값이 의도치 않게 변경되면, 버그나 논리적 오류가 발생한 가능성 있음.
+  > 하지만 **모든 값을 검증하는 것은 비효율적**이므로,
+    **변경되지 않는 값 중 핵심적인 값들만 검증**하여 테스트의 효율성을 유지.
+  - 핵심 식별자(예: id, seller, code, name 등)가 의도치 않게 변경되지 않았는지 간단히 검증.
+  - 비즈니스 로직에 따라 중요한 값이 변경되지 않아야 하는 경우, 해당 값도 검증.
+
 1. Mockito의 verify()
    ~~~
     // then
@@ -761,6 +780,7 @@ OOP 관점에서 봤을 때 인터페이스는 다형성 혹은 개방 폐쇄 �
         assertTrue(capturedDuration.toMillis() <= validTime, "Duration should be less than or equal to validTime");
         ~~~
 
+
 ### < 테스트코드작성 ArgumentCaptor >
 - 참고블로그 https://hanrabong.com/entry/Test-ArgumentCaptor%EB%9E%80
 - capture()
@@ -775,6 +795,90 @@ OOP 관점에서 봤을 때 인터페이스는 다형성 혹은 개방 폐쇄 �
   - memberRepository.save() 실행 여부 체크
 
 
+### < 테스트코드 전달인자 검증 >
+- 참고 ProductionServiceTest.successModifyProduction()
+- 주로 toDto **메소드에 전달된 값들이 의도한 대로 정확히 전달되었는지를 확인**.
+
+- 전달인자 검증방법
+  - ArgumentCaptor를 사용하여 전달인자를 캡처한 뒤 이를 검증하면 해당 객체가 수정된 값들을 정확하게 포함하고 있는지 확인가능.
+  - 이 테스트 코드에서는 전달인자 검증이 중요한 부분이므로
+    ArgumentCaptor를 사용해 toDto 메소드로 전달된 Production 객체의 속성값들이 예상대로 처리되었는지 검증하는 핖요.
+
+- ArgumentCaptor 사용해 전달인자 검증 예시
+  ~~~
+    // ArgumentCaptor 생성
+    ArgumentCaptor<Production> productionCaptor = ArgumentCaptor.forClass(Production.class);
+    
+    // stub(가설) : productionMapper.toDto() 실행 시 productionCaptor로 인자를 캡처하도록 설정.
+    given(productionMapper.toDto(productionCaptor.capture()))
+        .willReturn(expectedResultProductionDto);
+    
+    // when
+    ResponseProductionDto responseProductionDto =
+        productionService.modifyProduction(requestProductionDto, member);
+    
+    // then
+    // 1. 상품 수정 검증
+    assertEquals(requestProductionDto.getId(), responseProductionDto.getId());
+    assertEquals(requestProductionDto.getDescription(), responseProductionDto.getDescription());
+    assertEquals(requestProductionDto.getSaleStatus(), responseProductionDto.getSaleStatus());
+    assertEquals(originProductionEntity.getSeller(), responseProductionDto.getSeller());
+    assertEquals(originProductionEntity.getCode(), responseProductionDto.getCode());
+    assertEquals(originProductionEntity.getName(), responseProductionDto.getName());
+    assertEquals(originProductionEntity.getCategory(), responseProductionDto.getCategory());
+    
+    // 2. 상품옵션 수정 검증
+    RequestModifyProductionOptionDto requestUpdateOption = requestProductionDto.getOptions().get(0);
+    ResponseProductionOptionDto responseUpdatedOption = responseProductionDto.getOptions().get(0);
+    assertEquals(requestUpdateOption.getId(), responseUpdatedOption.getId());
+    assertEquals(requestUpdateOption.getQuantity(), responseUpdatedOption.getQuantity());
+    
+    // 3. 상품옵션 신규등록 검증
+    RequestModifyProductionOptionDto requestInsertOption = requestProductionDto.getOptions().get(1);
+    ResponseProductionOptionDto responseInsertedOption = responseProductionDto.getOptions().get(1);
+    assertNull(requestInsertOption.getId());
+    assertEquals(3L, responseInsertedOption.getId());
+    
+    // 4. toDto에 전달된 인자 캡처 후 검증
+    Production capturedProduction = productionCaptor.getValue();
+    assertEquals(updateDescription, capturedProduction.getDescription());
+    assertEquals(updateSaleStatus, capturedProduction.getSaleStatus());
+    assertEquals(productionId, capturedProduction.getId());
+  ~~~
+    1. Production 객체에 대한 검증
+       - toDto 메소드로 전달된 Production 객체가 수정된 설명(updateDescription)과 판매 상태(updateSaleStatus)를 정확히 포함하는지 검증.
+    
+    2. ProductionOption 객체에 대한 검증
+       - ResponseProductionOptionDto가 수정된 quantity와 일치하는지, 그리고 신규 추가된 옵션에 대해서도 id 값이나 quantity 값이 예상대로 처리되는지 검증.
+    
+    3. toDto에 전달된 Production 객체 검증
+       - ArgumentCaptor를 사용하여 productionMapper.toDto()로 전달된 Production 객체를 캡처하고, 그 값들을 검증합니다.
+    
+    4. 옵션 quantity 및 price 값이 올바르게 전달되는지 확인
+       - ProductionOption에 대해 업데이트와 삽입된 옵션이 quantity와 price를 올바르게 갖고 있는지 검증합니다.
+
+1. productionMapper.toDto() 메소드의 전달인자 검증
+    - 메소드가 호출되었을 때, 실제로 Production 객체가 올바르게 전달되었는지 확인가능.
+    - expectedProductionEntity가 productionMapper.toDto()에 전달된 객체일 때,
+      그 객체가 올바르게 수정된 값들을 포함하고 있는지 확인하는 것입니다.
+
+2. modifyProductionOptionMapper.toEntity() 메소드의 전달인자 검증
+    - RequestModifyProductionOptionDto 객체를 ProductionOption으로 변환하는 로직.
+    - 이 과정에서 전달되는 DTO 값들이 실제로 Entity로 올바르게 변환되는지 검증.
+    - quantity나 price 값이 제대로 전달되는지 검증가능.
+
+3. ProductionOption 관련 인자들 검증
+    - 수정된 옵션(RequestModifyProductionOptionDto)들이
+      실제로 서비스 로직에 전달될 때 값들이 올바르게 전달되었는지 확인 필요.
+    - RequestModifyProductionOptionDto에서 quantity, price, optionCode 등이 올바르게 설정되었는지 확인가능.
+    - expectedResponseOptionDtoList에 있는 값들이 요청 DTO에서 예상한 값과 일치하는지 검증가능.
+
+4. 서비스 내에서 인자 검증
+    - productionService.modifyProduction()에서 인자들이 올바르게 처리되는지도 중요한 검증 대상.
+    - requestProductionDto의 값들이 제대로 전달되었는지.
+    - productionService.modifyProduction() 내부에서 originProductionEntity에 대한 수정이 예상대로 이루어졌는지.
+
+      
 ### < Reflection - private 메서드 테스트코드 작성 >
 - 리플렉션을 사용 시 클래스의 메서드나 필드에 직접 접근할 수 없더라도 접근 제어자에 관계없이 해당 클래스의 메서드나 필드를 검사하거나 수정가능.
 - 자바의 java.lang.reflect 패키지에서 제공되는 클래스를 사용.

--- a/study/jpa-study.md
+++ b/study/jpa-study.md
@@ -454,3 +454,170 @@ public class Order {
   }
   ~~~  
 
+
+---
+### < dirty 체크 >
+- **Entity의 속성이 변경된 상태**
+  - Entity가 변경되었음을 JPA가 인식하고, DB에 반영될 준비가 된 상태.
+- ProductionOption 엔티티에서 quantity 값을 변경했다면, 해당 엔티티는 "dirty" 상태로 간주.
+- JPA는 해당 엔티티가 변경되었음을 추적합니다.
+
+1. JPA가 dirty check를 인식할 수 있는 이유
+   - JPA는 영속성 컨텍스트라는 메커니즘을 사용하여 엔티티의 상태를 추적. 
+   - 영속성 컨텍스트는 데이터베이스와의 연결을 관리하는 메모리상의 객체 상태를 의미. 
+   - 이 컨텍스트 내에서 엔티티의 상태가 변경되면, JPA는 이를 추적하고,  
+     flush() 또는 save()가 호출될 때 자동으로 DB에 반영합니다.
+
+2. Entity의 상태
+   - Entity가 처음 로드된 경우
+     - 데이터베이스에서 엔티티를 가져오면 영속성 컨텍스트에 보관되고, 
+       이 상태에서 **Entity는 변경되지 않은 상태**.
+     
+   - Entity가 수정된 경우
+     - Entity의 필드값을 변경하면, JPA는 이 Entity가 "dirty" 상태로 바뀌었다고 인식. 
+     - 필드값이 변경되었으므로 **수정된 상태는 flush()나 save()가 호출될 때 DB에 변경사항이 반영**됨.
+
+   - Entity에 저장되지 않은 변경사항이 있는 경우
+     - Entity가 "dirty" 상태로 **변경되었지만 save() 또는 flush()가 호출되지 않으면 
+       변경사항은 DB에 반영되지 않음.**
+
+3. dirty 상태 추적과 DB반영
+   - JPA는 자동으로 변경된 엔티티를 감지하고 
+     DB에 반영하기 위해 flush() 또는 save() 메서드를 호출할 때 이 변경사항 적용. 
+   - 이를 통해 코드에서 명시적으로 Entity save()를 호출하지 않더라도, 
+     영속성 컨텍스트 내에서 변경된 상태를 추적하고 반영 가능.
+
+
+---
+### < @Transaction 어노테이션을 이용한 flush() >
+- **@Transactional은 엔티티가 영속성 컨텍스트에 의해 관리되는 경우에만 자동으로 flush하고 저장** 처리를 수행.
+  - @Transactional 어노테이션을 사용 시 
+    **save()를 명시적으로 호출하지 않더라도 엔티티의 변경 사항이 자동으로 DB에 저장 가능.** 
+    하지만, 이 동작은 몇 가지 조건 하에서만 적용됩니다.
+
+1. @Transactional의 동작 원리
+   - @Transactional 어노테이션이 붙은 메서드는 트랜잭션을 관리하는 역할 수행. 
+   - **트랜잭션이 완료될 때, 영속성 컨텍스트에 있는 모든 변경사항을 자동으로 DB에 반영.** 
+   - 트랜잭션 범위 내에서 엔티티의 상태가 변경되면 **메서드가 끝날 때 자동으로 flush가 발생**하고 commit.
+
+2. 영속성 컨텍스트에서 관리되는 Entity
+   - @Transactional이 적용된 메서드 내에서 이미 영속성 컨텍스트에 관리되는 엔티티가 수정되면, 
+     트랜잭션이 종료될 때 JPA가 자동으로 변경 사항을 감지하고, flush()를 호출하여 DB에 반영합니다.
+   ~~~
+    @Transactional
+    public ResponseProductionDto modifyProduction(RequestModifyProductionDto requestProductionDto, Member member) {
+        // 기존 옵션 목록 dto -> entity 변환
+        List<ProductionOption> requestUpdateOptionList = requestProductionDto.getOptions().stream()
+            .filter(option -> option.getId() != null && option.getId() > 0)
+            .map(modifyProductionOptionMapper::toEntity)
+            .toList();
+    
+        // 상품 수정 (영속성 컨텍스트에 의해 관리되는 상태)
+        Production production = productionRepository.findByIdAndSeller(requestProductionDto.getId(), member.getId())
+                .orElseThrow(() -> new ProductionException(NO_EDIT_PERMISSION));
+    
+        // 수정된 옵션 목록에 대한 변경
+        for (ProductionOption option : requestUpdateOptionList) {
+            // 이때, option은 "dirty" 상태로 변경됨
+            option.setQuantity(newQuantity);  
+        }
+    
+        // 트랜잭션이 끝날 때 JPA가 자동으로 flush() 호출 -> 변경사항이 DB에 반영됨
+        return productionMapper.toDto(production);
+    }
+   ~~~
+   - @Transactional이 적용된 메서드 내에서 production과 그 관련 ProductionOption 객체들을 수정하는 경우, 
+     트랜잭션이 종료될 때 자동으로 변경사항이 DB에 반영됩니다. 
+     여기서 save() 메서드를 명시적으로 호출하지 않더라도,  
+     트랜잭션 범위 내에서 수정된 Entity들은 자동으로 DB에 저장됩니다.
+
+3. 영속성 컨텍스트 외의 객체
+   - 만약 Entity가 영속성 컨텍스트 외부에서 생성되었거나 별도로 관리되지 않는 Entity인 경우,  
+     @Transactional은 그 엔티티의 변경사항을 자동으로 DB에 반영하지 않습니다. 
+   - 이 경우, 명시적으로 save()를 호출해야 DB에 반영됩니다.
+
+
+---
+### < 연관관계에 있는 Entity의 저장방식 >
+- ProductionOption의 경우 Production Entity와 연관관계가 있기 때문에, 
+  JPA에서 관리하는 영속성 컨텍스트 내에서 Production Entity가 변경되면 
+  연관된 ProductionOption도 함께 변경되어야 할 것 같습니다. 
+
+- 하지만 연관관계에 있는 자식 Entity(ProductionOption)가 자동으로 저장되지 않도록 설정된 경우, 
+  직접적으로 save() 호출을 해줘야 합니다.
+
+1. 영속성 컨텍스트 내에서 자동 저장되는 경우
+   - JPA에서는 부모 Entity가 자식 Entity와 연관관계가 있을 때,  
+     cascade 속성이 설정된 경우 자식 Entity도 부모 Entity의 변경과 함께 자동으로 저장됩니다. 
+   - @OneToMany 관계에서 cascade = CascadeType.PERSIST나 cascade = CascadeType.ALL이 설정되어 있다면, 
+     부모 Entity가 저장될 때 자식 Entity도 자동으로 저장됩니다.
+   ~~~
+    public class Production extends BaseEntity {
+        // ...
+        
+        // 상품:옵션 (1:N)
+        // CascadeType.ALL로 설정 시, 부모 엔티티를 저장할 때 자식 엔티티도 자동 저장됨.
+        @OneToMany(cascade = CascadeType.ALL, mappedBy = "production")
+        private List<ProductionOption> options; // 한 상품이 여러 옵션을 가질 수 있음.
+    }
+   ~~~
+
+2. 수동으로 save()를 호출해야 하는 경우
+   - cascade 속성이 설정되지 않은 경우 Production 엔티티에 대한 변경만 이루어지고
+     연관된 ProductionOption Entity는 따로 명시적으로 저장해야 합니다. 
+   - ProductionOption의 변경 사항이 
+     영속성 컨텍스트에서 관리되지 않도록 설정되어 있거나, cascade가 설정되지 않았다면, 
+     productionOptionRepository.save(option)을 통해 수동으로 ProductionOption을 저장해야 합니다.
+
+
+---
+### < 부모-자식 관계의 기본적인 동작 >
+- 부모-자식 관계의 기본적인 동작은 상황에 따라 달라질 수 있습니다. 
+- 부모 엔티티를 수정한다고 해서 자식 엔티티(옵션 데이터)가 자동으로 저장되지 않으며, 
+  JPA에서 변경된 상태를 명시적으로 추적하지 않으면 자동으로 저장되지 않습니다.
+
+- 다만, 연관된 자식 엔티티가 영속성 컨텍스트에 의해 관리되고 있으면 트랜잭션 내에서 자식 엔티티도 자동으로 저장될 수 있습니다.
+
+1. 부모 엔티티와 자식 엔티티의 저장
+   - JPA에서 부모 엔티티가 수정되었다고 해서 자식 엔티티가 자동으로 저장되지 않습니다. 
+   - 부모 엔티티가 수정되어도 자식 엔티티가 수정되지 않거나 변경된 상태로 추적되지 않으면 
+     JPA는 자식 엔티티에 대한 save() 호출 없이 자동으로 DB에 반영하지 않습니다.
+
+2. 연관 관계에서 자식 엔티티 자동 저장
+   - 부모 엔티티와 자식 엔티티가 양방향 관계(예: @OneToMany와 @ManyToOne 등)일 때 
+     영속성 컨텍스트에서 자식 엔티티가 이미 관리되고 있으면, 
+     부모 엔티티의 상태가 변경되면서 자식 엔티티도 자동으로 저장될 수 있습니다. 
+   - 다만, 이때도 자식 엔티티가 명시적으로 수정되었는지 여부를 확인하는 과정이 필요합니다.
+
+3. @Transactional과 관련된 동작
+   - @Transactional을 사용하면 트랜잭션이 종료될 때 영속성 컨텍스트에 변경된 상태가 자동으로 DB에 반영됩니다. 
+   - 하지만 자식 엔티티의 변경 사항이 영속성 컨텍스트에 관리되지 않으면, 
+     부모 엔티티의 수정만 반영되고 자식 엔티티는 따로 save()를 호출해줘야 저장됩니다.
+
+4. 영속성 컨텍스트에 의해 관리되는 엔티티들
+   - 부모 엔티티와 자식 엔티티가 모두 영속성 컨텍스트에 의해 관리되면, 
+     트랜잭션이 끝날 때 JPA는 자동으로 부모와 자식 엔티티의 상태를 반영합니다. 
+   - 즉, 자식 엔티티가 save()를 명시적으로 호출하지 않아도 JPA가 자동으로 DB에 반영합니다.
+   
+5. CascadeType 설정
+   - 부모 엔티티에 @OneToMany, @ManyToMany 등 관계가 설정되어 있고 
+     cascade = CascadeType.ALL 또는 cascade = CascadeType.PERSIST와 같은 Cascade 옵션이 설정되어 있으면 
+     부모 엔티티를 저장할 때 자식 엔티티가 자동으로 저장됩니다.
+   ~~~
+   // 이 설정은 부모 엔티티인 Production이 저장될 때, 연관된 자식 엔티티인 options도 자동으로 저장되도록 합니다.
+   @OneToMany(mappedBy = "production", cascade = CascadeType.ALL)
+   private List<ProductionOption> options;
+   ~~~
+
+6. 부모 엔티티 수정만으로 자식 엔티티가 자동 저장을 위한 조건 
+   - 자식 엔티티가 영속성 컨텍스트에 의해 관리되고, CascadeType이 적절히 설정되어야 합니다. 
+     @Transactional이 적용된 메서드 내에서 영속성 컨텍스트가 관리하는 엔티티는 자동으로 저장됩니다.
+   - 그러나 @Transactional을 사용하여 트랜잭션 범위 내에서 부모 엔티티의 수정만 이루어진다고 하더라도, 
+     자식 엔티티가 영속성 컨텍스트에 의해 관리되고 Cascade 옵션이 활성화되었을 경우에만 자식 엔티티가 자동으로 DB에 반영됩니다.    
+     그렇지 않으면 명시적으로 save()를 호출해야 자식 엔티티도 DB에 저장됩니다.
+
+7. Production과 ProductionOption
+   - production의 options 필드는 @OneToMany 또는 @ManyToMany 등의 관계로 **자식 엔티티(옵션 데이터)**와 연결된 경우,
+     options 데이터는 연관된 자식 엔티티로 영속성 컨텍스트에 의해 관리되고 있기 때문에
+     부모 엔티티인 production이 트랜잭션 내에서 수정되면, 자식 엔티티인 options도 자동으로 저장될 수 있습니다.
+


### PR DESCRIPTION
Changes
---
1. 상품수정 api 생성
    > - validation check 
          - 상품 판매자 체크 (본인이 판매하는 상품에 대해서만 변경가능.)
          - 상품의 기존 판매상태 체크
          - 상품옵션 목록 중복 체크 (요청한 옵션들 끼리의 중복 체크, 등록된 옵션과의 중복체크)
          - 수정 요청 옵션 중 등록되지 않은 옵션에 대해 옵션ID 체크
    > - 상품, 상품옵션 수정 가능.
    > - 상품에 대한 신규 상품옵션 등록 가능.
    > - 상품에 대해 설명, 판매상태 변경 가능.
    > - 판매상태가 DELETION(삭제)인 경우 수정 불가.
    > - 상품판매상태 도메인에 DISCONTINUED(판매중단) 추가.
    >    -  ON_SALE(판매중) : 현재 판매중으로 고객이 상품 검색 시 화면에 노출.
    >    - DISCONTINUED(판매중단) : 고객이 상품 검색 시 화면에 해당 상품을 노출하지 않는 상태로 추후 판매중, 삭제로 상태변경 가능.
    >    - DELETION(삭제) : 추후 해당 상품에 대해 관리 불가.
          
2. 상품등록 메서드 리팩토링 시 제거하지 않은 saveProductionOption() 메서드 제거
    > 해당 메서드 리팩토링 전, 후 메서드 둘 다 존재하므로 리팩토링 전 메서드 제거.
    

Test
---
- [x] API 호출 테스트
- [ ] Controller 테스트코드 작성 및 테스트
- [x] Service 성공 테스트 케이스 작성 및 테스트
  > repository.save()를 명시적으로 호출하지 않고 dirty checking하는 것은 단위테스트 영역 밖이므로 통합테스트 구현필요.
- [ ] Service 실패 테스트 케이스 작성 및 테스트


Discuss
---
1. 역할별 상이한 api 제공
    > - 셀러, 고객 역할에 따라 조회되어야할 데이터가 다른 경우, controller를 별도 관리하는 것이 어떨지 궁금합니다.
          (한 고객이 단일 역할을 가지는 것이 아니라 셀러 역할을 가진 유저가 고객 역할도 가질 수 있을 때 기준입니다.)
    > - 예를 들어 상품 관련 api를 /production 으로 제공합니다.
          이 때 셀러에게 상품목록 조회 기능으로는 자신이 등록한 상품목록 관리를 위해 본인등록 상품목록을 제공하고자하고, 고객에게 상품목록 조회 기능으로는 검색한 상품목록을 제공하려 합니다.
    > - 이런 경우 GET 요청으로 /customer/production, /seller/production 으로 별도로 분리해 해결할 수 있을 듯 한데 어떨까요?

2. 메서드 추출 시 동일 메서드 중복 호출
    > - 참고 조회 메서드 getProductionEntityByIdAndSeller()
    > - 유효성 검증 메서드를 분리하게 되면 유효성 검증 시 상품ID, 판매자ID에 해당하는 데이터를 조회하고
         상품의 수정사항 반영을 위해 상품ID, 판매자ID에 해당하는 데이터를 재조회하게 됩니다. 
	 동일 메서드를 2번 호출하게 되거나 유효성검증 메서드가 반환값으로 조회 결과를 반환하는 방법 두 가지를 생각할 수 있었습니다.
	 유효성검증 메서드가 조회 결과를 반환하게 되면 2가지의 역할을 가지게 되어 역할 분리가 되지 않는 것 같아 조회를 2번 수행하는 방법을 선택했습니다.
	 합리적인 방법일까요?

3. repository.save()를 명시적으로 호출하지 않은 경우 단위테스트 작성 어려움
   > - 참고 : ProductionServiceTest.java의 successModifyProduction()
   > - modifyProduction() 서비스는 명시적으로 save()를 호출하지 않고 dirty checking을 통해 데이터를 저장하도록 구현했습니다.      
        트랜잭션 종료 시 영속성 컨텍스트를 DB에 자동 commit하도록 서비스 로직을 구현하는 것이니까 repository.save() 메서드는 호출이 되어야 한다고 생각합니다.      
       실제로 해당 서비스 api를 호출하면 update, insert문이 정상 수행되니까요.
    > - 테스트코드 작성 시 verify(productionRepository).save()를 통해 save() 호출여부를 검증하고싶은데 호출되지 않았다는 오류가 발생합니다.      
     실제 디버그하면 로직은 모두 stub의 내용을 잘 반영해 서비스 로직은 정상 수행되지만 save() 호출 부분에 대해서는 해결이 어렵습니다.
    > - 우선 서비스 코드에 productionRepository.save()를 명시적으로 호출하는 것으로 테스트코드를 작성해 수행되도록 반영했습니다.
    > - 서비스코드에서 repository.save()를 명시적으로 호출하지 않고 dirty checking한 내용을 트랜잭션 종료 시 자동 반영할 때 정상 수행하는 테스트코드를 작성하고 싶습니다.       
	 dirty checking이 되지 않는 것인지, 트랜잭션 종료 시 dirty checking 변경사항을 반영하기 위해 추가 테스트코드가 필요한 것인지 모르겠습니다.     
	 어떻게 해결할 수 있는지, 제가 어떤 부분은 간과하고 있는지 알려주시면 감사하겠습니다.

